### PR TITLE
Undefined Variable Error & Cross-Drive File Moving Error

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -490,7 +490,7 @@ class OnePaceRenamer:
                 safe_title = rsub(cls.illegal_filename_chars, "", episode_info["title"])
 
                 new_video_file_path = Path(season_path, f"{prefix}{safe_title}{filepath.suffix}")
-                filepath.rename(new_video_file_path)
+                shmove(str(filepath), str(new_video_file_path))
 
                 queue.append((new_video_file_path, episode_info))
 
@@ -720,12 +720,12 @@ class OnePaceRenamer:
 
                 ET.indent(episodedetails)
                 ET.ElementTree(episodedetails).write(
-                    str(Path(season_path, f"{filename}.nfo")), 
+                    str(Path(season_path, f"{prefix}{safe_title}.nfo")), 
                     encoding='utf-8', 
                     xml_declaration=True
                 )
                 
-                filepath.rename(new_video_file_path)
+                shmove(str(filepath), str(new_video_file_path))
 
                 if total > 0:
                     set_percentage(int((i / total) * 100))


### PR DESCRIPTION
Heyja, tried to get this working on my Win machine and ran into two errors

- First was an undefined Variable
`NameError: name 'filename' is not defined`
Solution: Replace filename with prefix + safe_title in NFO file creation

- 2nd issue was regards moving the files to a different drive
`[WinError 17] Cannot move file to different drive`
Solution: Replace filepath.rename() with shutil.move()
This should make it more reliable for cross-platform compatibility