### PR TITLE
fix: load pyproject.toml before version check

### DIFF
--- a/src/console.py
+++ b/src/console.py
@@ -72,6 +72,9 @@ class Console:
     async def run(self):
         self._set_logger_sink(sys.stderr)
 
+        if self.organizer.toml is None or not self.organizer.toml.get("version", ""):
+            self.organizer.toml = utils.get_toml_info(self.organizer.base_path)
+        
         is_latest, latest_vers = await utils.run(utils.is_up_to_date, self.organizer.toml["version"], self.organizer.base_path)
         if not is_latest:
             await message_dialog(


### PR DESCRIPTION
Resolves error below

```Traceback (most recent call last):
  File "/home/appuser/OnePaceOrganizer/main.py", line 175, in <module>
    main()
  File "/home/appuser/OnePaceOrganizer/main.py", line 165, in main
    console.main(opo, log_level)
  File "/home/appuser/OnePaceOrganizer/src/console.py", line 535, in main
    code = asyncio.run(Console(organizer, log_level).run())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/appuser/homebrew/opt/python@3.12/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/home/appuser/homebrew/opt/python@3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/appuser/homebrew/opt/python@3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/appuser/OnePaceOrganizer/src/console.py", line 75, in run
    is_latest, latest_vers = await utils.run(utils.is_up_to_date, self.organizer.toml["version"], self.organizer.base_path)```