### PR TITLE
Add check for empty "last_login" config field

### DIFF
--- a/src/organizer.py
+++ b/src/organizer.py
@@ -164,7 +164,7 @@ class OnePaceOrganizer:
             if "enabled" in config["plex"] and config["plex"]["enabled"] is not None:
                 self.mode = 1
 
-            if "last_login" in config["plex"] and config["plex"]["last_login"] is not None:
+            if "last_login" in config["plex"] and config["plex"]["last_login"] is not None and config["plex"]["last_login"] != "":
                 self.plex_last_login = datetime.datetime.fromisoformat(config["plex"]["last_login"])
 
             if "url" in config["plex"] and config["plex"]["url"] is not None and config["plex"]["url"] != "":


### PR DESCRIPTION
Added another `!= ""` check to the config loading to fix the issue where the program crashes as `""` is not a valid isoformat of a date.

Theoretically this would also work
```
if "last_login" in config["plex"] and config["plex"]["last_login"]:
    self.plex_last_login = datetime.datetime.fromisoformat(config["plex"]["last_login"])
```
as both `None` and empty string get evaluated to false in python.
But there are other cases where the explicit `None` and `!= ""` is done and I didn't want to stray from the used way.

Fixes: [30](https://github.com/ladyisatis/OnePaceOrganizer/issues/30)