### PR TITLE
BUG Fixes and new Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ __marimo__/
 
 # VSCode
 .vscode
+
+# Metadata
+metadata

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# VSCode
+.vscode

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Metadata is sourced from [one-pace-metadata](https://github.com/ladyisatis/one-p
 
 Contributions via Pull Requests are always welcome if I miss a bug or want another feature added in, want to contribute a program icon, etc.
 
+## Running from source
+
+Details are available [on the wiki](https://github.com/ladyisatis/OnePaceOrganizer/wiki/Frequently-Asked-Questions#how-do-i-run-this-from-source), but in short you can run this from source by running:
+
+```bash
+  uv run main.py gui
+```
+
 ## Thanks
 
 - Craigy (@verywittyname on Discord) for Episode Descriptions spreadsheets and updates

--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ def main():
         parser.add_argument("--plex-library", help="Plex Library Key", default=None)
         parser.add_argument("--plex-show", help="Plex Show GUID", default=None)
         parser.add_argument("--plex-set-show-edits", help="Overwrite Plex show information", default=None, type=strbool)
-        parser.add_argument("--plex-scan-show-folder", help="Tells Plex to scan show folder before updating metadata", default=None, type=strbool)
+        parser.add_argument("--plex-scan-show-folder", help="Trigger Plex Library scan after moving/copying", default=None, type=strbool)
         parser.add_argument("--plex-code", help="Plex 2-Factor Auth Code (headless mode only)", default=None)
         parser.add_argument("--plex-remember", help="Remember Plex Credentials", default=None, type=strbool)
         parser.add_argument("--plex-retry-times", help="How many times Organizer should retry to fetch a Plex season/episode", default=None)

--- a/main.py
+++ b/main.py
@@ -80,6 +80,7 @@ def main():
         parser.add_argument("--plex-library", help="Plex Library Key", default=None)
         parser.add_argument("--plex-show", help="Plex Show GUID", default=None)
         parser.add_argument("--plex-set-show-edits", help="Overwrite Plex show information", default=None, type=strbool)
+        parser.add_argument("--plex-scan-show-folder", help="Tells Plex to scan show folder before updating metadata", default=None, type=strbool)
         parser.add_argument("--plex-code", help="Plex 2-Factor Auth Code (headless mode only)", default=None)
         parser.add_argument("--plex-remember", help="Remember Plex Credentials", default=None, type=strbool)
         parser.add_argument("--plex-retry-times", help="How many times Organizer should retry to fetch a Plex season/episode", default=None)
@@ -144,6 +145,9 @@ def main():
 
         if args.plex_set_show_edits is not None:
             opo.plex_set_show_edits = args.plex_set_show_edits
+
+        if args.plex_scan_show_folder is not None:
+            opo.plex_scan_show_folder = args.plex_scan_show_folder
 
         if args.plex_retry_times is not None:
             opo.plex_retry_times = int(args.plex_retry_times)

--- a/src/console.py
+++ b/src/console.py
@@ -324,7 +324,15 @@ class Console:
                         ("Set It Myself", False)
                     ]
                 ).run_async()
-                #TODO plex_scan_show_folder
+
+                self.organizer.plex_scan_show_folder = await button_dialog(
+                    title=self.window_title,
+                    text="Do you want to trigger Plex to Scan the Library files after import or there's no need? (eg if Plex settings do that automatically already)",
+                    buttons=[
+                        ("Tell Plex to Scan", True),
+                        ("No need", False)
+                    ]
+                ).run_async()
 
         if plex_config_enabled:
             success = await self.run_plex_wizard()

--- a/src/console.py
+++ b/src/console.py
@@ -324,6 +324,7 @@ class Console:
                         ("Set It Myself", False)
                     ]
                 ).run_async()
+                #TODO plex_scan_show_folder
 
         if plex_config_enabled:
             success = await self.run_plex_wizard()

--- a/src/gui.py
+++ b/src/gui.py
@@ -1146,10 +1146,12 @@ class GUI(QMainWindow):
         self.plex_status.prop.setText(self.plex_status_text())
 
     @asyncClose
-    async def exit(self, event=None):
+    async def closeEvent(self, event):
         await self.organizer.save_config()
-        if event is None:
-            self.close()
+        event.accept()
+
+    def exit(self):
+        self.close()  # delegates to closeEvent above
 
     def set_action(self, action):
         self.organizer.file_action = action
@@ -1355,8 +1357,9 @@ class GUI(QMainWindow):
 def main(organizer, log_level):
     try:
         app = QApplication(sys.argv)
-        close_event = asyncio.Event()
-        app.aboutToQuit.connect(close_event.set)
+
+        loop = QEventLoop(app)
+        asyncio.set_event_loop(loop)
 
         async def _run():
             await organizer.load_config()
@@ -1364,7 +1367,7 @@ def main(organizer, log_level):
             gui = GUI(organizer, log_level)
             gui.setWindowTitle(organizer.window_title)
 
-            if "gui_maximized" in organizer.extra_fields and isinstance(organizer.extra_fields["gui_maximized"], bool) and organizer.extra_fields["gui_maximized"]:
+            if organizer.extra_fields.get("gui_maximized") is True:
                 gui.showMaximized()
             else:
                 gui.show()
@@ -1372,27 +1375,23 @@ def main(organizer, log_level):
             is_latest, latest_vers = await utils.run(utils.is_up_to_date, organizer.toml["version"], organizer.base_path)
             if not is_latest:
                 do_update = await asyncWrap(
-                    QMessageBox.question(
+                    lambda: QMessageBox.question(
                         None,
-                        self.organizer.window_title,
-                        "There is a newer version of this application. Do you wish to open up " +
-                        "GitHub in order to download the new version?" +
-                        "\n\n" +
-                        f"Installed: v{organizer.toml['version']}\n" +
+                        organizer.window_title,
+                        "There is a newer version of this application. Do you wish to open up "
+                        "GitHub in order to download the new version?"
+                        "\n\n"
+                        f"Installed: v{organizer.toml['version']}\n"
                         f"Latest: v{latest_vers}"
                     ) == QMessageBox.StandardButton.Yes
                 )
-
                 if do_update:
                     await utils.run(webbrowser.open_new_tab, "https://github.com/ladyisatis/OnePaceOrganizer/releases/latest")
 
-            await close_event.wait()
+        with loop:
+            loop.run_until_complete(_run())
+            loop.run_forever()  # keeps running until app.quit() / window close exits the loop
 
-        asyncio.run(_run(), loop_factory=QEventLoop)
-
-    except:
+    except Exception:
         print(traceback.format_exc())
         QMessageBox.critical(None, organizer.window_title, traceback.format_exc())
-
-    finally:
-        asyncio.run(organizer.save_config())

--- a/src/gui.py
+++ b/src/gui.py
@@ -298,13 +298,6 @@ class GUI(QMainWindow):
         self.action_edit_plex_url.triggered.connect(self.edit_plex_url)
         menu_configuration.addAction(self.action_edit_plex_url)
 
-        self.action_scan_show_folder = QAction("Tell Plex to scan the series folder before updating metadata", self)
-        self.action_scan_show_folder.setCheckable(True)
-        self.action_scan_show_folder.setChecked(self.organizer.plex_scan_show_folder)
-        self.action_scan_show_folder.setVisible(self.organizer.mode != 0)
-        self.action_scan_show_folder.triggered.connect(self.scan_show_folder)
-        menu_configuration.addAction(self.action_scan_show_folder)
-
         self.action_overwrite_nfo = QAction("Overwrite .nfo Files", self)
         self.action_overwrite_nfo.setCheckable(True)
         self.action_overwrite_nfo.setChecked(self.organizer.overwrite_nfo)
@@ -347,6 +340,13 @@ class GUI(QMainWindow):
         self.action_edit_plex_retry_secs.setVisible(self.organizer.mode != 0)
         self.action_edit_plex_retry_secs.triggered.connect(self.edit_plex_retry_secs)
         menu_advanced.addAction(self.action_edit_plex_retry_secs)
+
+        self.action_scan_show_folder = QAction("(Plex) Scan Library after move/copy", self)
+        self.action_scan_show_folder.setCheckable(True)
+        self.action_scan_show_folder.setChecked(self.organizer.plex_scan_show_folder)
+        self.action_scan_show_folder.setVisible(self.organizer.mode != 0)
+        self.action_scan_show_folder.triggered.connect(self.scan_show_folder)
+        menu_advanced.addAction(self.action_scan_show_folder)
 
         action_edit_workers = QAction("Edit Number of Workers", self)
         action_edit_workers.triggered.connect(self.edit_workers)

--- a/src/gui.py
+++ b/src/gui.py
@@ -298,6 +298,13 @@ class GUI(QMainWindow):
         self.action_edit_plex_url.triggered.connect(self.edit_plex_url)
         menu_configuration.addAction(self.action_edit_plex_url)
 
+        self.action_scan_show_folder = QAction("Tell Plex to scan the series folder before updating metadata", self)
+        self.action_scan_show_folder.setCheckable(True)
+        self.action_scan_show_folder.setChecked(self.organizer.plex_scan_show_folder)
+        self.action_scan_show_folder.setVisible(self.organizer.mode != 0)
+        self.action_scan_show_folder.triggered.connect(self.scan_show_folder)
+        menu_configuration.addAction(self.action_scan_show_folder)
+
         self.action_overwrite_nfo = QAction("Overwrite .nfo Files", self)
         self.action_overwrite_nfo.setCheckable(True)
         self.action_overwrite_nfo.setChecked(self.organizer.overwrite_nfo)
@@ -620,6 +627,7 @@ class GUI(QMainWindow):
         self.action_edit_plex_retry_secs.setVisible(plex_enabled)
         self.action_overwrite_nfo.setVisible(not plex_enabled)
         self.action_set_show.setVisible(plex_enabled)
+        self.action_scan_show_folder.setVisible(plex_enabled)
         self.output.setVisible(self.organizer.file_action != 4)
         self.input.label.setText(self.input_metadata_str if self.organizer.file_action == 4 else self.input_nometadata_str)
         self.input.setVisible(self.organizer.file_action != 4 if plex_enabled else True)
@@ -1224,6 +1232,10 @@ class GUI(QMainWindow):
     def set_show_edits(self):
         self.organizer.plex_set_show_edits = not self.organizer.plex_set_show_edits
         self.action_set_show.setChecked(self.organizer.plex_set_show_edits)
+
+    def scan_show_folder(self):
+        self.organizer.plex_scan_show_folder = not self.organizer.plex_scan_show_folder
+        self.action_scan_show_folder.setChecked(self.organizer.plex_scan_show_folder)
 
     @asyncSlot()
     async def start(self):

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -98,7 +98,7 @@ class OnePaceOrganizer:
         self.plex_retry_secs = utils.get_env("plex_retry_secs", 30)
         self.plex_retry_times = utils.get_env("plex_retry_times", 3)
         self.plex_set_show_edits = utils.get_env("plex_set_show_edits", True)
-        self.plex_scan_show_folder = utils.get_env("plex_scan_show_folder", True)
+        self.plex_scan_show_folder = utils.get_env("plex_scan_show_folder", False)
 
         self.progress_bar_func = None
         self.message_dialog_func = None

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -98,6 +98,7 @@ class OnePaceOrganizer:
         self.plex_retry_secs = utils.get_env("plex_retry_secs", 30)
         self.plex_retry_times = utils.get_env("plex_retry_times", 3)
         self.plex_set_show_edits = utils.get_env("plex_set_show_edits", True)
+        self.plex_scan_show_folder = utils.get_env("plex_scan_show_folder", True)
 
         self.progress_bar_func = None
         self.message_dialog_func = None
@@ -228,6 +229,9 @@ class OnePaceOrganizer:
             if "set_show_edits" in config["plex"] and config["plex"]["set_show_edits"] is not None:
                 self.plex_set_show_edits = config["plex"]["set_show_edits"]
 
+            if "scan_show_folder" in config["plex"] and config["plex"]["scan_show_folder"] is not None:
+                self.plex_scan_show_folder = config["plex"]["scan_show_folder"]
+
         if "mode" in config and config["mode"] is not None and isinstance(config["mode"], int):
             self.mode = config["mode"]
 
@@ -279,7 +283,8 @@ class OnePaceOrganizer:
                 },
                 "retry_secs": self.plex_retry_secs,
                 "retry_times": self.plex_retry_times,
-                "set_show_edits": self.plex_set_show_edits
+                "set_show_edits": self.plex_set_show_edits,
+                "scan_show_folder": self.plex_scan_show_folder
             }
         }
 
@@ -1085,6 +1090,10 @@ class OnePaceOrganizer:
                                 await utils.run(show.editOriginallyAvailable, str(tvshow["premiered"].isoformat()).split("T")[0])
                             else:
                                 await utils.run(show.editOriginallyAvailable, tvshow["premiered"])
+                
+                if self.plex_scan_show_folder:
+                    self.logger.info("Asking plex to scan folder")
+
 
             # Poster
             src = await utils.run(utils.find_from_list, self.base_path, [

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -98,7 +98,7 @@ class OnePaceOrganizer:
         self.plex_retry_secs = utils.get_env("plex_retry_secs", 30)
         self.plex_retry_times = utils.get_env("plex_retry_times", 3)
         self.plex_set_show_edits = utils.get_env("plex_set_show_edits", True)
-        self.plex_scan_show_folder = utils.get_env("plex_scan_show_folder", False)
+        self.plex_scan_show_folder = utils.get_env("plex_scan_show_folder", True)
 
         self.progress_bar_func = None
         self.message_dialog_func = None

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -1091,10 +1091,6 @@ class OnePaceOrganizer:
                             else:
                                 await utils.run(show.editOriginallyAvailable, tvshow["premiered"])
                 
-                if self.plex_scan_show_folder:
-                    self.logger.info("Asking plex to scan folder")
-
-
             # Poster
             src = await utils.run(utils.find_from_list, self.base_path, [
                 ("posters", "poster.*"),
@@ -1245,7 +1241,17 @@ class OnePaceOrganizer:
         plex_episode = None
 
         try:
+            data_file = Path(self.base_path, "metadata", "data.db")
+            if await utils.is_file(data_file):
+                await self.open_db(data_file)
+
             section = await utils.run(self.plexapi_server.library.sectionByID, int(self.plex_config_library_key))
+
+            if self.plex_scan_show_folder:
+                self.logger.info(f"Triggering Plex Library Scan")
+                section.update()
+                self.logger.debug(f"Waiting 5 seconds for library update to finish")
+                await asyncio.sleep(5)
 
             self.logger.trace(f"Looking up show with GUID: {self.plex_config_show_guid}")
             if self.plex_config_show_guid.startswith("local://"):


### PR DESCRIPTION
## BUG FIXES:

- #38 (reworked gui close handler)
- #29 (db was closed when trying to process plex episodes)
- #17 (possibly, I think the user just wasn't manuallu scanning library files)


## New Feature
I added a bool to che config to Trigger a Plex Library Update.

### Why?
Lots of people have plex configured not to scan new files automatically.
This is to avoid plex displaying movies/episodes you already had as "recently added" whenever radarr/sonarr grabs a better file.

### What happens then?
Currently after importing the new episodes we try updating metadata, but this results in it not finding anything on plex.
Usually what I've been doing is manually triggering plex before clicking OK.
This previously wasn't working because of #29 , so it works now, but at the same time I added the new feature to do this automatically.

### How?

I added the toggle here (default to True)
<img width="537" height="409" alt="image" src="https://github.com/user-attachments/assets/ef53a81e-ebd6-4307-9c8f-c3adff227aa7" />

When this is checked, after importing the files (before trying to update metadata) we trigger a plex library update.

**NOTE:** Unfortunately I could find no reliable way to subscribe to plex events to wait till the scan is over. Currently I'm just waiting 5 seconds and in my testing that's plenty when there's just a few new One Pace episodes to scan, and if it fails the app already retries after 30 seconds so that's good.
However in the future we could definitely wait for the library update in a better way altho I couldn't find one so far.

